### PR TITLE
Remove vestiges of python 2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 docutils==0.16
-six
 Sphinx==4.3.2

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Framework :: Sphinx :: Extension',
         'Topic :: Documentation',
@@ -43,7 +42,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'docutils',
-        'six',
         'Sphinx',
     ],
     namespace_packages=['sphinxcontrib']

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -22,7 +22,6 @@ from docutils import nodes
 from docutils.nodes import Node
 from docutils.parsers.rst.states import Inliner
 from docutils.parsers.rst import directives
-from six import iteritems
 
 from sphinx import addnodes
 from sphinx.environment import BuildEnvironment
@@ -685,7 +684,7 @@ class ChapelModuleIndex(Index):
         ignores = sorted(ignores, key=len, reverse=True)
 
         # list of all modules, sorted by module name
-        modules = sorted(iteritems(self.domain.data['modules']),
+        modules = sorted(self.domain.data['modules'].items(),
                          key=lambda x: x[0].lower())
 
         # sort out collapsible modules
@@ -739,7 +738,7 @@ class ChapelModuleIndex(Index):
         collapse = len(modules) - num_toplevels < num_toplevels
 
         # sort by first leter
-        content = sorted(iteritems(content))
+        content = sorted(content.items())
 
         return content, collapse
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@ mock
 nose
 nose-cov
 tox
-unittest2

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -9,10 +9,6 @@ import mock
 import sys
 import unittest
 
-# For python 2.6 and lower, use unittest2.
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    import unittest2 as unittest
-
 from sphinxcontrib.chapeldomain import (
     ChapelDomain, ChapelModuleIndex, ChapelModuleLevel, ChapelObject,
     ChapelTypedField,


### PR DESCRIPTION
38 started requiring python3, so remove python2 specific code. We don't
need six and can just use python3 features and don't need unittest2,
which was a backport of unittest to old python2 versions.